### PR TITLE
fix(imports): correct RunnableConfig import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ During web searches, if a single webpage contains too much information, we also 
 ### 1. Configure the research
 
 ```python
-from langgraph_core.runnables import RunnableConfig
+from langchain_core.runnables import RunnableConfig
 from State.state import ReportStateInput
 from report_writer import graph, DEFAULT_REPORT_STRUCTURE
 


### PR DESCRIPTION
### 🎯 Motivation
The `RunnableConfig` class is currently imported from `langgraph_core.runnables`. According to the latest architecture of the `langchain` ecosystem, the canonical source for this class is `langchain_core.runnables`. This incorrect import path leads to an `ImportError` in standard environments, preventing dependent functionalities from working.

### ✨ Changes Made
- Corrected the import statement for `RunnableConfig` to use `langchain_core.runnables` instead of `langgraph_core.runnables`.

**Code Difference:**
```diff
- from langgraph_core.runnables import RunnableConfig
+ from langchain_core.runnables import RunnableConfig