### PR TITLE
fix(agentic-search): fix 4 bugs in agentic_search.py (closes #16 #17 #18 #19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ raw*
 # ── Navigator generated files ─────────────────────────────────────────
 reader_tmp/
 navigator_tmp/
+AGENTS.md
+
+# ── Git worktrees ─────────────────────────────────────────────────────
+.worktrees/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,13 @@ ROOT = Path(__file__).resolve().parent.parent
 
 
 # ---------------------------------------------------------------------------
+# Custom markers
+# ---------------------------------------------------------------------------
+def pytest_configure(config):
+    config.addinivalue_line("markers", "integration: integration tests that run without external services")
+
+
+# ---------------------------------------------------------------------------
 # Fake config that satisfies every module-level OmegaConf.load() call
 # ---------------------------------------------------------------------------
 FAKE_CONFIG = {

--- a/tests/test_agentic_search.py
+++ b/tests/test_agentic_search.py
@@ -1,14 +1,17 @@
 """Tests for subagent.agentic_search — tool_calls guards (C8) and followed_up_queries default (I10)."""
 
 import asyncio
+import logging
 from unittest.mock import MagicMock, patch
 
+import pytest
 from langgraph.graph import END
 
 from subagent.agentic_search import (
     check_search_quality_async,
     check_searching_results,
     compress_raw_content,
+    filter_and_format_results,
     perform_web_search,
     queries_rewriter,
 )
@@ -52,7 +55,7 @@ class TestCheckSearchQualityGuard:
         mock_result = MagicMock()
         mock_result.tool_calls = []
         with patch("subagent.agentic_search.call_llm_async", return_value=mock_result):
-            score = asyncio.get_event_loop().run_until_complete(check_search_quality_async("query", "document text"))
+            score = asyncio.run(check_search_quality_async("query", "document text"))
         assert score == 0
 
     def test_returns_score_on_success(self):
@@ -60,7 +63,7 @@ class TestCheckSearchQualityGuard:
         mock_result = MagicMock()
         mock_result.tool_calls = [{"args": {"score": 4}}]
         with patch("subagent.agentic_search.call_llm_async", return_value=mock_result):
-            score = asyncio.get_event_loop().run_until_complete(check_search_quality_async("query", "document text"))
+            score = asyncio.run(check_search_quality_async("query", "document text"))
         assert score == 4
 
 
@@ -82,7 +85,7 @@ class TestCompressRawContentGuard:
             ],
         }
         with patch("subagent.agentic_search.call_llm_async", return_value=mock_compressed):
-            result = asyncio.get_event_loop().run_until_complete(compress_raw_content(state))
+            result = asyncio.run(compress_raw_content(state))
 
         # Should fall back to original result
         assert len(result["compressed_web_results"][0]["results"]) == 1
@@ -166,3 +169,227 @@ class TestFollowedUpQueriesDefault:
         with patch("subagent.agentic_search.selenium_api_search", return_value=[{"results": []}]) as mock_search:
             perform_web_search(state)
         mock_search.assert_called_once_with(["follow up query"], True)
+
+    def test_url_memo_returned_in_state(self):
+        """url_memo must be included in the return dict so LangGraph persists it across iterations."""
+        state = {
+            "queries": ["q1"],
+            "url_memo": set(),
+            "curr_num_iterations": 0,
+        }
+        fake_results = [{"results": [{"url": "http://a.com", "title": "A", "content": "c", "raw_content": "r"}]}]
+        with patch("subagent.agentic_search.selenium_api_search", return_value=fake_results):
+            result = perform_web_search(state)
+        assert "url_memo" in result
+        assert "http://a.com" in result["url_memo"]
+
+    def test_url_memo_deduplicates_across_iterations(self):
+        """A URL seen in iteration 1 must be excluded in iteration 2."""
+        seen_url = "http://dup.com"
+        state_iter1 = {
+            "queries": ["q1"],
+            "url_memo": set(),
+            "curr_num_iterations": 0,
+        }
+        fake_results = [{"results": [{"url": seen_url, "title": "T", "content": "c", "raw_content": "r"}]}]
+        with patch("subagent.agentic_search.selenium_api_search", return_value=fake_results):
+            result1 = perform_web_search(state_iter1)
+
+        # Simulate LangGraph feeding back the returned url_memo as the next iteration's state
+        state_iter2 = {
+            "queries": ["q1"],
+            "url_memo": result1["url_memo"],
+            "curr_num_iterations": result1["curr_num_iterations"],
+        }
+        with patch("subagent.agentic_search.selenium_api_search", return_value=fake_results):
+            result2 = perform_web_search(state_iter2)
+
+        assert result2["web_results"][0]["results"] == [], "duplicate URL should be filtered out in second iteration"
+
+    def test_url_memo_partial_dedup_within_batch(self):
+        """url_memo pre-seeded with one URL: that URL is filtered, new URL passes through."""
+        state = {
+            "queries": ["q1"],
+            "url_memo": {"http://seen.com"},
+            "curr_num_iterations": 1,
+        }
+        fake_results = [{"results": [
+            {"url": "http://seen.com", "title": "old", "content": "c", "raw_content": "r"},
+            {"url": "http://new.com",  "title": "new", "content": "c", "raw_content": "r"},
+        ]}]
+        with patch("subagent.agentic_search.selenium_api_search", return_value=fake_results):
+            result = perform_web_search(state)
+
+        urls_in_results = [r["url"] for r in result["web_results"][0]["results"]]
+        assert "http://seen.com" not in urls_in_results
+        assert "http://new.com" in urls_in_results
+        assert "http://seen.com" in result["url_memo"]
+        assert "http://new.com" in result["url_memo"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by filter_and_format_results tests
+# ---------------------------------------------------------------------------
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _filter_state(results_per_query: list[list[dict]]) -> dict:
+    return {
+        "queries": [f"q{i}" for i in range(len(results_per_query))],
+        "followed_up_queries": [],
+        "web_results": [{"results": items} for items in results_per_query],
+    }
+
+
+# ---------------------------------------------------------------------------
+# #17 — LLM failure during quality check must not silently drop all results
+# ---------------------------------------------------------------------------
+class TestQualityFilterLLMFailure:
+    def test_llm_failure_includes_result_in_output(self):
+        """#17: When call_llm_async raises during quality check, result must still appear in output."""
+        state = _filter_state([[{"url": "http://x.com", "title": "T", "content": "C", "raw_content": "R"}]])
+        with patch("subagent.agentic_search.call_llm_async", side_effect=Exception("LLM down")):
+            result = _run(filter_and_format_results(state))
+        assert len(result["filtered_web_results"][0]["results"]) == 1, (
+            "result must be preserved when quality LLM fails, not silently dropped"
+        )
+
+    def test_all_results_included_when_entire_llm_fails(self):
+        """
+        Fail-open policy: when call_llm_async fails for every result,
+        all results must be included rather than producing an empty corpus.
+        """
+        state = _filter_state([
+            [
+                {"url": "http://a.com", "title": "T", "content": "C", "raw_content": "R"},
+                {"url": "http://b.com", "title": "T", "content": "C", "raw_content": "R"},
+            ]
+        ])
+        with patch("subagent.agentic_search.call_llm_async", side_effect=Exception("LLM down")):
+            result = _run(filter_and_format_results(state))
+        assert len(result["filtered_web_results"][0]["results"]) == 2, (
+            "both results must be preserved when quality LLM is entirely unavailable"
+        )
+
+
+# ---------------------------------------------------------------------------
+# #18 — Diagnostic events (quality failures, compression failures) must be logged at ERROR
+#        so they are visible under the module's ERROR-level logger
+# ---------------------------------------------------------------------------
+class TestLoggerLevel:
+    def test_quality_check_failure_emits_error_log(self, caplog):
+        """#18: Quality check failure must emit an ERROR log so it is not suppressed."""
+        state = _filter_state([[{"url": "http://x.com", "title": "T", "content": "C", "raw_content": "R"}]])
+        with patch("subagent.agentic_search.call_llm_async", side_effect=Exception("LLM down")):
+            with caplog.at_level(logging.ERROR, logger="AgenticSearch"):
+                _run(filter_and_format_results(state))
+        error_messages = [r.message for r in caplog.records if r.levelno == logging.ERROR]
+        assert any("Quality check failed" in msg for msg in error_messages), (
+            "ERROR log must be emitted when quality check fails so it is visible under ERROR-level logger"
+        )
+
+
+# ---------------------------------------------------------------------------
+# #19 — Regression: per-task exception must not prevent other results processing
+# ---------------------------------------------------------------------------
+class TestScoreThresholdAndExceptionHandling:
+    def test_failing_quality_for_one_query_does_not_drop_other_query_results(self):
+        """#19 regression: A low/failed quality check for q0 must not prevent q1 results from appearing."""
+        state = _filter_state([
+            [{"url": "http://low.com", "title": "T", "content": "C", "raw_content": "R"}],
+            [{"url": "http://high.com", "title": "T", "content": "C", "raw_content": "R"}],
+        ])
+        call_count = 0
+
+        async def fake_llm(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            mock = MagicMock()
+            mock.tool_calls = [{"args": {"score": 1 if call_count == 1 else 5}}]
+            return mock
+
+        with patch("subagent.agentic_search.call_llm_async", side_effect=fake_llm):
+            result = _run(filter_and_format_results(state))
+
+        assert len(result["filtered_web_results"][0]["results"]) == 0, "score=1 should be filtered"
+        assert len(result["filtered_web_results"][1]["results"]) == 1, "score=5 should pass"
+
+    def test_gather_level_exception_drops_that_result_but_preserves_others(self):
+        """
+        #19 regression: if a coroutine propagates an exception into gather's return list
+        (the isinstance branch), that result is dropped but others are still processed.
+        This guards against future refactors that move the inner try/except out of the closure.
+        """
+        state = _filter_state([
+            [{"url": "http://fail.com", "title": "T", "content": "C", "raw_content": "R"}],
+            [{"url": "http://pass.com", "title": "T", "content": "C", "raw_content": "R"}],
+        ])
+
+        async def fake_gather(*coros, return_exceptions=False):
+            # Inject a raw Exception as the first element (simulates propagated coroutine failure)
+            results = [RuntimeError("simulated propagated exception")]
+            for coro in list(coros)[1:]:
+                results.append(await coro)
+            return results
+
+        mock_llm = MagicMock()
+        mock_llm.tool_calls = [{"args": {"score": 5}}]
+
+        with patch("subagent.agentic_search.call_llm_async", return_value=mock_llm):
+            with patch("subagent.agentic_search.asyncio.gather", side_effect=fake_gather):
+                result = _run(filter_and_format_results(state))
+
+        # First result dropped (isinstance Exception branch hits continue)
+        assert len(result["filtered_web_results"][0]["results"]) == 0
+        # Second result still processes normally
+        assert len(result["filtered_web_results"][1]["results"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Helper shared by compress_raw_content tests
+# ---------------------------------------------------------------------------
+def _compress_state(results_per_query: list[list[dict]]) -> dict:
+    return {
+        "queries": [f"q{i}" for i in range(len(results_per_query))],
+        "followed_up_queries": [],
+        "filtered_web_results": [{"results": items} for items in results_per_query],
+    }
+
+
+# ---------------------------------------------------------------------------
+# compress_raw_content LLM failure — original content must be preserved
+# ---------------------------------------------------------------------------
+class TestCompressRawContentLLMFailure:
+    def test_llm_exception_preserves_original_content(self):
+        """
+        When call_llm_async raises during compression, the original result
+        must be preserved unchanged (compress_content_with_metadata returns None,
+        outer loop falls through to else branch and appends original_result).
+        """
+        original = {"url": "http://x.com", "title": "T", "content": "C", "raw_content": "RC"}
+        state = _compress_state([[original]])
+        with patch("subagent.agentic_search.call_llm_async", side_effect=Exception("LLM down")):
+            result = _run(compress_raw_content(state))
+        assert len(result["compressed_web_results"][0]["results"]) == 1, (
+            "original result must be preserved when compression LLM raises"
+        )
+        assert result["compressed_web_results"][0]["results"][0]["raw_content"] == "RC", (
+            "raw_content must be the original, not replaced with empty summary"
+        )
+
+    def test_llm_exception_emits_error_log(self, caplog):
+        """
+        When call_llm_async raises during compression, an ERROR log must be emitted
+        so it is visible under the module's ERROR-level logger.
+        """
+        state = _compress_state(
+            [[{"url": "http://x.com", "title": "T", "content": "C", "raw_content": "RC"}]]
+        )
+        with patch("subagent.agentic_search.call_llm_async", side_effect=Exception("LLM down")):
+            with caplog.at_level(logging.ERROR, logger="AgenticSearch"):
+                _run(compress_raw_content(state))
+        error_messages = [r.message for r in caplog.records if r.levelno == logging.ERROR]
+        assert any("Content compression failed" in msg for msg in error_messages), (
+            "ERROR log must be emitted when compression LLM raises"
+        )

--- a/tests/test_agentic_search_integration.py
+++ b/tests/test_agentic_search_integration.py
@@ -1,0 +1,230 @@
+"""Integration tests for the agentic search LangGraph graph.
+
+These tests verify that LangGraph correctly propagates state across the
+``check_searching_results → perform_web_search`` back-edge when the graph
+loops.  The node-level deduplication behaviour of ``perform_web_search`` is
+already covered by unit tests in ``test_agentic_search.py``; what is tested
+here is whether the ``url_memo`` set returned by ``perform_web_search`` in
+iteration 1 actually appears in the state received by ``perform_web_search``
+in iteration 2 after travelling through the full graph cycle.
+
+Markers
+-------
+pytest.mark.integration — runs alongside the unit suite; no external services
+needed (all I/O mocked).
+"""
+
+import asyncio
+import functools
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "integration: full-graph LangGraph state propagation integration tests",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Shared fake data
+# ---------------------------------------------------------------------------
+
+_DUP_URL = "http://dup.com"
+
+# A single search result whose URL is always the same.  ``perform_web_search``
+# uses ``url_memo`` to filter duplicate URLs across iterations.
+_FAKE_SEARCH_RESPONSE = [
+    {
+        "results": [
+            {
+                "url": _DUP_URL,
+                "title": "Dup Title",
+                "content": "Some content.",
+                "raw_content": "Some raw content.",
+            }
+        ]
+    }
+]
+
+# How many iterations the test should allow.
+_MAX_ITERATIONS = 2
+
+
+# ---------------------------------------------------------------------------
+# Async mock for call_llm_async (quality check + compression)
+# ---------------------------------------------------------------------------
+
+async def _fake_call_llm_async(*args, **kwargs):
+    """Async drop-in for ``call_llm_async``.
+
+    Dispatches on the tool name (``quality_formatter`` vs ``summary_formatter``):
+    * ``quality_formatter`` — returns score=5 so every result passes the filter.
+    * ``summary_formatter`` — returns a stub summary so compression succeeds.
+    """
+    tool_list = kwargs.get("tool", [])
+    # LangChain @tool decorators expose a .name attribute on the wrapped callable.
+    tool_name = tool_list[0].name if tool_list else ""
+
+    mock_response = MagicMock()
+    if tool_name == "quality_formatter":
+        mock_response.tool_calls = [{"args": {"score": 5}}]
+    elif tool_name == "summary_formatter":
+        mock_response.tool_calls = [{"args": {"summary_content": "stub summary"}}]
+    else:
+        mock_response.tool_calls = [{"args": {"score": 5}}]
+    return mock_response
+
+
+# ---------------------------------------------------------------------------
+# Synchronous mock for call_llm (grader in check_searching_results)
+# ---------------------------------------------------------------------------
+
+def _make_call_llm_fail_response():
+    """Build the ``call_llm`` return value that makes the grader return 'fail'.
+
+    ``check_searching_results`` accesses ``feedback.tool_calls[0]['args']``.
+    Returning grade='fail' causes the graph to loop back to perform_web_search.
+    After iteration 2 the budget guard short-circuits before calling the LLM,
+    so this mock is exercised exactly once.
+    """
+    mock_response = MagicMock()
+    mock_response.tool_calls = [
+        {"args": {"grade": "fail", "follow_up_queries": ["follow up query"]}}
+    ]
+    return mock_response
+
+
+# ---------------------------------------------------------------------------
+# Helper: wrap perform_web_search to inject max_num_iterations into state
+# ---------------------------------------------------------------------------
+
+def _make_perform_web_search_wrapper(real_fn, max_iter: int):
+    """Wrap ``perform_web_search`` to inject ``max_num_iterations`` into its
+    state update.
+
+    Context: ``agentic_search_graph`` is a module-level singleton compiled once
+    at import time.  Its nodes store direct Python function-object references;
+    ``patch('subagent.agentic_search.get_searching_budget', ...)`` does not
+    affect the already-compiled graph.  Wrapping ``perform_web_search`` —
+    called at the start of every loop cycle — is the least-invasive way to
+    propagate the test-controlled budget into live state without requiring graph
+    recompilation.
+
+    ``selenium_api_search`` is patched at the outer ``with`` level so that it
+    is already replaced by the time ``real_fn`` executes.
+    """
+
+    def wrapper(state):
+        result = real_fn(state)
+        result["max_num_iterations"] = max_iter
+        return result
+
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Integration test
+# ---------------------------------------------------------------------------
+
+@pytest.mark.integration
+class TestAgenticSearchGraphUrlMemoPropagation:
+    """Verify that LangGraph propagates url_memo across the search loop back-edge.
+
+    The graph is:
+        START → get_searching_budget → perform_web_search
+              → filter_and_format_results → compress_raw_content
+              → aggregate_final_results → check_searching_results
+              → (loops to perform_web_search if grade='fail', else END)
+
+    With ``max_num_iterations=2`` the graph executes two full cycles.  After
+    iteration 1, ``url_memo`` contains ``_DUP_URL``.  LangGraph must feed that
+    updated set back into ``perform_web_search`` for iteration 2 so that the
+    duplicate URL is filtered out and not added to ``web_results`` again.
+
+    The test asserts three things that only hold if LangGraph propagates the
+    set correctly:
+    1. ``_DUP_URL`` appears in the final ``url_memo``.
+    2. ``selenium_api_search`` is called exactly twice (one per iteration).
+    3. ``_DUP_URL`` appears exactly once in the final ``source_str``
+       (deduplication worked — iteration 2 contributed no new results).
+    """
+
+    def test_url_memo_propagated_across_loop(self):
+        """LangGraph propagates url_memo set through the check_searching_results back-edge.
+
+        Implementation note: ``agentic_search_graph`` is compiled once at import;
+        its nodes hold direct function references that ``patch()`` on the module
+        namespace cannot override after the fact.  This test therefore directly
+        mutates ``RunnableCallable.func`` (used by sync invoke) and ``afunc``
+        (used by LangGraph's async executor via ``ainvoke``) on the compiled
+        ``perform_web_search`` node, injecting a wrapper that adds
+        ``max_num_iterations=2`` to the state update.  The original callables are
+        restored in a ``finally`` block so that no state leaks to other tests.
+        """
+        import subagent.agentic_search as ag
+        from subagent.agentic_search import agentic_search_graph, perform_web_search
+
+        wrapped_perform = _make_perform_web_search_wrapper(perform_web_search, _MAX_ITERATIONS)
+
+        # Patch the compiled graph's perform_web_search node in-place.
+        # The ``RunnableCallable`` stores two references:
+        #   .func  — called by the sync Pregel runner
+        #   .afunc — called by the async Pregel runner (ainvoke path) as
+        #            functools.partial(run_in_executor, None, original_func)
+        node = agentic_search_graph.nodes["perform_web_search"]
+        runnable = node.bound  # langgraph._internal._runnable.RunnableCallable
+        original_func = runnable.func
+        original_afunc = runnable.afunc
+
+        # Replace .func with the wrapper.
+        runnable.func = wrapped_perform
+        # Replace .afunc with a new partial pointing to the wrapper so that the
+        # asyncio thread-pool executor also sees the patched version.
+        runnable.afunc = functools.partial(original_afunc.func, None, wrapped_perform)
+
+        call_llm_response = _make_call_llm_fail_response()
+
+        try:
+            async def _run():
+                return await agentic_search_graph.ainvoke(
+                    {"queries": ["test query"], "url_memo": set()}
+                )
+
+            with (
+                patch.object(
+                    ag,
+                    "selenium_api_search",
+                    return_value=_FAKE_SEARCH_RESPONSE,
+                ) as mock_search,
+                patch.object(ag, "call_llm_async", side_effect=_fake_call_llm_async),
+                patch.object(ag, "call_llm", return_value=call_llm_response),
+            ):
+                final_state = asyncio.run(_run())
+        finally:
+            # Restore originals to avoid polluting subsequent tests.
+            runnable.func = original_func
+            runnable.afunc = original_afunc
+
+        # 1. The URL seen in iteration 1 must survive in the final url_memo.
+        assert _DUP_URL in final_state["url_memo"], (
+            f"{_DUP_URL!r} must be present in final url_memo; "
+            "got: " + repr(final_state["url_memo"])
+        )
+
+        # 2. One selenium_api_search call per iteration = 2 total.
+        assert mock_search.call_count == 2, (
+            "Expected 2 selenium_api_search calls (one per iteration), "
+            f"got {mock_search.call_count}"
+        )
+
+        # 3. The URL appears exactly once in source_str — dedup prevented
+        #    iteration 2 from contributing any new results for that URL.
+        source_str = final_state.get("source_str", "")
+        occurrences = source_str.count(_DUP_URL)
+        assert occurrences == 1, (
+            f"Expected {_DUP_URL!r} to appear exactly once in source_str "
+            f"(dedup via url_memo), but found {occurrences} occurrence(s)."
+        )

--- a/tests/test_agentic_search_integration.py
+++ b/tests/test_agentic_search_integration.py
@@ -21,13 +21,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def pytest_configure(config):
-    config.addinivalue_line(
-        "markers",
-        "integration: full-graph LangGraph state propagation integration tests",
-    )
-
-
 # ---------------------------------------------------------------------------
 # Shared fake data
 # ---------------------------------------------------------------------------

--- a/tests/test_text_navigator_integration.py
+++ b/tests/test_text_navigator_integration.py
@@ -22,10 +22,6 @@ from Tools.reader_models import sanitize_name
 from Tools.text_navigator import AgentDocumentReader
 
 
-def pytest_configure(config):
-    config.addinivalue_line("markers", "integration: Chroma SQLite cache integration tests")
-
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes four bugs in `subagent/agentic_search.py` reported in issues #16–#19.

- **#16 — url_memo dedup silently broken across iterations**: `perform_web_search` now returns `url_memo` in its state update dict so LangGraph persists the seen-URL set; previously the in-place `set.add()` was local and lost on every follow-up iteration.
- **#17 — Quality filter LLM failure drops entire corpus**: `check_quality_with_metadata` returns `score=None` on exception (was `score=0`). The result loop includes `None`-score results (fail-open policy) rather than filtering them through the `score > 2` gate, preventing a single LLM outage from producing an empty corpus.
- **#18 — Diagnostic events suppressed by `logger.setLevel(ERROR)`**: Quality-check, compression, and parse-failure log calls raised from `logger.warning` to `logger.error` so they are visible under the module's ERROR-level logger.
- **#19 — Dead `try/except` around `asyncio.gather(return_exceptions=True)`**: Removed the unreachable `try/except` in both `filter_and_format_results` and `compress_raw_content`; `asyncio.gather` with `return_exceptions=True` never raises — exceptions surface as list elements, already handled by the `isinstance(result, Exception)` loop. Those loop-level logs also raised to `error`.

## Test plan

- [ ] `pytest tests/test_agentic_search.py` — 21 unit tests (11 existing + 10 new), all passing
  - `TestFollowedUpQueriesDefault`: 2 new tests for `url_memo` returned in state and cross-iteration dedup + 1 partial-dedup edge case
  - `TestQualityFilterLLMFailure`: LLM failure preserves result + fail-open policy with full batch failure
  - `TestLoggerLevel`: quality failure emits ERROR log
  - `TestScoreThresholdAndExceptionHandling`: score threshold filtering + `isinstance(Exception)` gather branch
  - `TestCompressRawContentLLMFailure`: compression LLM exception preserves original + emits ERROR log
- [ ] `pytest tests/test_agentic_search_integration.py` — 1 integration test verifying LangGraph propagates `url_memo` set across the `check_searching_results → perform_web_search` back-edge across two real graph iterations (mocked LLM/Selenium)
- [ ] `pytest tests/` — full suite (168 + 22 = 190 tests), all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)