### PR TITLE
fix(#20,#21): fix url_memo serialization and type-annotate WebResult/WebResultBatch

### DIFF
--- a/State/agentic_search_state.py
+++ b/State/agentic_search_state.py
@@ -1,5 +1,17 @@
 import operator
-from typing import Annotated, TypedDict
+from typing import Annotated, NotRequired, TypedDict
+
+
+class WebResult(TypedDict):
+    title: str
+    content: str
+    raw_content: str
+    url: str
+    score: NotRequired[int]
+
+
+class WebResultBatch(TypedDict):
+    results: list[WebResult]
 
 
 class AgenticSearchState(TypedDict):
@@ -8,9 +20,10 @@ class AgenticSearchState(TypedDict):
     # Search queries generated internally by generate_queries_from_question
     queries: list[str]
     followed_up_queries: list[str]
-    web_results: list[dict]
-    filtered_web_results: list[dict]
-    compressed_web_results: list[dict]
+    # Parallel lists — must all have len == len(queries); zip() silently truncates if they differ
+    web_results: list[WebResultBatch]
+    filtered_web_results: list[WebResultBatch]
+    compressed_web_results: list[WebResultBatch]
     # Current iteration's formatted search results (reset each round)
     materials: str
     # Iteratively updated answer with inline citations (persists across rounds)
@@ -18,7 +31,7 @@ class AgenticSearchState(TypedDict):
     max_num_iterations: int
     curr_num_iterations: int
     num_queries: int
-    url_memo: set[str]
+    url_memo: list[str]
     # Append-only registry of {title, url} for all quality-passed sources.
     # Position + 1 = stable citation number [N] across iterations.
     source_registry: Annotated[list[dict], operator.add]

--- a/report_writer.py
+++ b/report_writer.py
@@ -407,7 +407,7 @@ async def orchestration(state: SectionState, config: RunnableConfig):
             "question": current_question.question,
             "max_num_iterations": agentic_search_iterations,
             "num_queries": agentic_search_queries,
-            "url_memo": set(),
+            "url_memo": [],
             "source_registry": [],
         })
         answer = search_results.get("answer", "")

--- a/subagent/agentic_search.py
+++ b/subagent/agentic_search.py
@@ -204,7 +204,7 @@ def generate_queries_from_question(state: AgenticSearchState):
 
 
 def perform_web_search(state: AgenticSearchState):
-    url_memo = state.get("url_memo", set())
+    url_memo = set(state.get("url_memo", []))
     queries = state["queries"]
     curr_num_iterations = state.get("curr_num_iterations", 0)
     followed_up_queries = state.get("followed_up_queries", [])
@@ -235,7 +235,7 @@ def perform_web_search(state: AgenticSearchState):
     return {
         "web_results": dedup_results,
         "curr_num_iterations": curr_num_iterations + 1,
-        "url_memo": url_memo,
+        "url_memo": list(url_memo),
     }
 
 
@@ -612,7 +612,7 @@ if __name__ == "__main__":
         t_start = t_prev
 
         async for event in agentic_search_graph.astream(
-            {"question": question, "url_memo": set(), "source_registry": [], "max_num_iterations": num_iterations},
+            {"question": question, "url_memo": [], "source_registry": [], "max_num_iterations": num_iterations},
             stream_mode="updates",
         ):
             t_now = time.perf_counter()

--- a/tests/test_agentic_search.py
+++ b/tests/test_agentic_search.py
@@ -173,7 +173,7 @@ class TestFollowedUpQueriesDefault:
         """Missing followed_up_queries key should default to [] not '' (I10 fix)."""
         state = {
             "queries": ["test query"],
-            "url_memo": set(),
+            "url_memo": [],
             "curr_num_iterations": 0,
             # followed_up_queries intentionally absent
         }
@@ -188,7 +188,7 @@ class TestFollowedUpQueriesDefault:
         state = {
             "queries": ["original"],
             "followed_up_queries": ["follow up query"],
-            "url_memo": set(),
+            "url_memo": [],
             "curr_num_iterations": 0,
         }
         with patch("subagent.agentic_search.call_search_engine", return_value=[{"results": []}]) as mock_search:
@@ -199,7 +199,7 @@ class TestFollowedUpQueriesDefault:
         """url_memo must be included in the return dict so LangGraph persists it across iterations."""
         state = {
             "queries": ["q1"],
-            "url_memo": set(),
+            "url_memo": [],
             "curr_num_iterations": 0,
         }
         fake_results = [{"results": [{"url": "http://a.com", "title": "A", "content": "c", "raw_content": "r"}]}]
@@ -213,7 +213,7 @@ class TestFollowedUpQueriesDefault:
         seen_url = "http://dup.com"
         state_iter1 = {
             "queries": ["q1"],
-            "url_memo": set(),
+            "url_memo": [],
             "curr_num_iterations": 0,
         }
         fake_results = [{"results": [{"url": seen_url, "title": "T", "content": "c", "raw_content": "r"}]}]
@@ -235,7 +235,7 @@ class TestFollowedUpQueriesDefault:
         """url_memo pre-seeded with one URL: that URL is filtered, new URL passes through."""
         state = {
             "queries": ["q1"],
-            "url_memo": {"http://seen.com"},
+            "url_memo": ["http://seen.com"],
             "curr_num_iterations": 1,
         }
         fake_results = [{"results": [
@@ -250,6 +250,54 @@ class TestFollowedUpQueriesDefault:
         assert "http://new.com" in urls_in_results
         assert "http://seen.com" in result["url_memo"]
         assert "http://new.com" in result["url_memo"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #21 — WebResult / WebResultBatch TypedDict schema
+# ---------------------------------------------------------------------------
+class TestWebResultTypedDicts:
+    def test_importable(self):
+        """WebResult and WebResultBatch must be importable from State.agentic_search_state."""
+        from State.agentic_search_state import WebResult, WebResultBatch  # noqa: F401
+
+    def test_web_result_required_keys(self):
+        """WebResult must declare the four required keys used throughout agentic_search nodes."""
+        from State.agentic_search_state import WebResult
+        required = {"title", "content", "raw_content", "url"}
+        # __required_keys__ is set by TypedDict for non-NotRequired fields
+        assert required <= WebResult.__required_keys__, (
+            f"WebResult missing required keys: {required - WebResult.__required_keys__}"
+        )
+
+    def test_web_result_score_is_optional(self):
+        """score must be NotRequired so results without a score are valid."""
+        from State.agentic_search_state import WebResult
+        assert "score" in WebResult.__optional_keys__, "score must be NotRequired in WebResult"
+
+    def test_web_result_batch_has_results_key(self):
+        """WebResultBatch must declare a 'results' key."""
+        from State.agentic_search_state import WebResultBatch
+        assert "results" in WebResultBatch.__required_keys__
+
+    def test_state_parallel_list_fields_use_web_result_batch(self):
+        """web_results, filtered_web_results, compressed_web_results must be list[WebResultBatch]."""
+        import ast
+        from .conftest import ROOT
+        source = (ROOT / "State" / "agentic_search_state.py").read_text()
+        tree = ast.parse(source)
+        # Collect annotated field names inside AgenticSearchState
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "AgenticSearchState":
+                for stmt in node.body:
+                    if isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                        field = stmt.target.id
+                        if field in ("web_results", "filtered_web_results", "compressed_web_results"):
+                            annotation = ast.unparse(stmt.annotation)
+                            assert "WebResultBatch" in annotation, (
+                                f"{field} annotation should reference WebResultBatch, got: {annotation}"
+                            )
+                return
+        raise AssertionError("AgenticSearchState class not found in agentic_search_state.py")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_agentic_search_integration.py
+++ b/tests/test_agentic_search_integration.py
@@ -201,7 +201,7 @@ class TestAgenticSearchGraphUrlMemoPropagation:
                 return await agentic_search_graph.ainvoke(
                     {
                         "question": "What are the key facts about this topic?",
-                        "url_memo": set(),
+                        "url_memo": [],
                         "source_registry": [],
                     }
                 )

--- a/tests/test_agentic_search_integration.py
+++ b/tests/test_agentic_search_integration.py
@@ -302,7 +302,7 @@ class TestSourceRegistryIntegration:
         async def _run():
             return await agentic_search_graph.ainvoke({
                 "question": "What is CPO?",
-                "url_memo": set(),
+                "url_memo": [],
                 "source_registry": [],
                 "max_num_iterations": 1,
             })
@@ -349,7 +349,7 @@ class TestSourceRegistryIntegration:
         async def _run():
             return await agentic_search_graph.ainvoke({
                 "question": "Test question",
-                "url_memo": set(),
+                "url_memo": [],
                 "source_registry": [],
                 "max_num_iterations": 2,
             })
@@ -448,7 +448,7 @@ class TestFinalizeAnswerNode:
         async def _run():
             return await agentic_search_graph.ainvoke({
                 "question": "What is the topic?",
-                "url_memo": set(),
+                "url_memo": [],
                 "source_registry": [],
                 "max_num_iterations": 1,
             })


### PR DESCRIPTION
## Summary

- **#20**: `url_memo` 從 `set[str]` 改為 `list[str]`，確保 LangGraph `SqliteSaver` checkpoint 時不會因 `set` 無法 JSON 序列化而 crash。`perform_web_search` 內部仍使用 `set` 做 O(1) dedup，return 時轉回 `list`。
- **#21**: 新增 `WebResult` 與 `WebResultBatch` TypedDict，取代 `web_results`、`filtered_web_results`、`compressed_web_results` 的 `list[dict]`，讓 dict schema 對 type checker 可見，並補充 parallel-list invariant 說明。

## Changes

| File | Change |
|------|--------|
| `State/agentic_search_state.py` | 新增 `WebResult`、`WebResultBatch` TypedDict；三個 list 欄位改為 `list[WebResultBatch]`；`url_memo: set[str]` → `list[str]` |
| `subagent/agentic_search.py` | `perform_web_search` 讀取時轉 set，return 時轉 list；初始 state `set()` → `[]` |
| `tests/test_agentic_search.py` | `url_memo` fixture 從 `set()` 改為 `[]`；新增 `TestWebResultTypedDicts` 5 個測試 |
| `tests/test_agentic_search_integration.py` | `url_memo` fixture 從 `set()` 改為 `[]` |

## Test plan

- [ ] `pytest tests/ -x -q` → 234 passed
- [ ] `TestWebResultTypedDicts` 5 個新測試驗證 TypedDict schema
- [ ] `TestFollowedUpQueriesDefault` url_memo 相關測試確認 dedup 行為不變

Closes #20
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)