### PR TITLE
refactor(tracing): unified Langfuse tracing API with proper span nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,44 @@ A modular and automated research report generation tool designed for **in-depth 
 
 ---
 
+## 🔭 Observability (Langfuse)
+
+All tracing is centralized in `Utils/langfuse_tracing.py`. Application code must **never import from `langfuse` directly** — always import from `Utils.langfuse_tracing`.
+
+### API
+
+| Function | Purpose |
+|----------|---------|
+| `langfuse_node(fn, name=, state_key=)` | Wrap every LangGraph node — creates a span that nests child calls automatically |
+| `traced(name)` | Context-manager span for `asyncio.gather` closures or arbitrary code blocks |
+| `traced_thread(fn, *args, **kwargs)` | Run sync function in `asyncio.to_thread` with OTel context propagated (prevents orphan spans) |
+| `observe` | Decorator for top-level entry points and standalone utility functions |
+| `get_langfuse_callback()` | Returns a LangChain `CallbackHandler` linked to the current Langfuse trace |
+
+### Key Rules
+
+1. **Single import source** — `from Utils.langfuse_tracing import langfuse_node, traced, ...`
+2. **All graph nodes use `langfuse_node()`** — use `state_key="section.name"` for parallel section disambiguation
+3. **Never use raw `asyncio.to_thread`** — use `traced_thread` to propagate OTel parent context to worker threads
+4. **`asyncio.gather` closures use `traced()`** — each concurrent task gets its own named span
+5. **`@observe` for entry points only** — not for LangGraph node functions
+
+```python
+# Graph node wrapping
+builder.add_node("my_node", langfuse_node(my_fn))
+builder.add_node("write",   langfuse_node(write_section, state_key="section.name"))
+
+# Sync graph in async context
+result = await traced_thread(graph.invoke, state, config)
+
+# Concurrent sub-agents
+async def _do_web():
+    with traced("web_search"):
+        return await search_graph.ainvoke(...)
+```
+
+---
+
 ## 📁 File Overview
 
 | File/Folder             | Description                                                                     |

--- a/Utils/langfuse_tracing.py
+++ b/Utils/langfuse_tracing.py
@@ -1,34 +1,49 @@
 """Langfuse observability utilities for LangGraph nodes.
 
-Langfuse 3.x API:
-  - observe() imported from langfuse (not langfuse.decorators)
-  - CallbackHandler() with no args auto-inherits current @observe trace context
-  - get_langfuse_callback() returns None if not inside a trace (avoids spurious root traces)
+Provides a small, unified API so callers never touch OTel or Langfuse internals
+directly. All context-propagation edge cases (threads, asyncio.gather, subgraphs)
+are handled here.
+
+Public API
+----------
+langfuse_node(fn, ...)     — wrap a LangGraph node (sync or async)
+traced(name)               — context manager span (sync `with` only)
+traced_thread(fn, *a, **kw)— run sync fn in thread WITH parent span propagated
+observe                    — re-exported from langfuse for @observe on entry points
+get_langfuse_callback()    — LangChain CallbackHandler linked to current span
 
 Usage in graph builders:
     from Utils.langfuse_tracing import langfuse_node
     builder.add_node("my_node", langfuse_node(my_node_fn))
 
-Entry points (top-level traces):
-    from langfuse import observe
+    # Disambiguate parallel sections:
+    builder.add_node("orchestration", langfuse_node(orchestration, state_key="section.name"))
 
-    @observe(name="agentic_search")
-    async def _run():
+Entry points (top-level traces):
+    from Utils.langfuse_tracing import observe
+
+    @observe(name="report_writer")
+    async def run():
         ...
+
+Thread boundary (sync graph in async node):
+    from Utils.langfuse_tracing import traced_thread
+    result = await traced_thread(graph.invoke, initial_state, config)
+
+Manual span (e.g. inside asyncio.gather closures):
+    from Utils.langfuse_tracing import traced
+    async def _do_web():
+        with traced("agentic_web_search"):
+            return await agentic_search_graph.ainvoke(...)
 """
+import asyncio
 import functools
 import inspect
 import sys as _sys
 
-# Conditional imports: only bind these names if they are not already present in the module
-# namespace. This ensures that test patches applied via unittest.mock.patch(...) before an
-# importlib.reload() call are preserved — reload() re-executes the module body in the SAME
-# namespace without clearing it first, so a pre-existing attribute (set by patch) survives
-# as long as the module code does not unconditionally overwrite it.
-#
-# Test-patching requirement: patches must be applied BEFORE this module is first imported,
-# or tests must call importlib.reload(langfuse_tracing) after patching. On a fresh import
-# the guard always evaluates False and the real langfuse symbols are bound.
+# ---------------------------------------------------------------------------
+# Conditional imports — preserve test patches across reload()
+# ---------------------------------------------------------------------------
 if "observe" not in vars():
     from langfuse import observe  # type: ignore[assignment]  # noqa: PLC0415
 if "get_client" not in vars():
@@ -37,53 +52,128 @@ if "CallbackHandler" not in vars():
     from langfuse.langchain import CallbackHandler  # type: ignore[assignment]  # noqa: PLC0415
 
 
-def langfuse_node(fn, name: str | None = None):
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+def _get_dynamic_span_name(span_name: str, state_key: str | None, args) -> str:
+    """Build a span name, optionally appending a value from state for disambiguation.
+
+    When state_key is provided and the first positional arg (state dict) contains it,
+    the span name becomes "span_name [value]", e.g. "orchestration [半導體分析]".
+    """
+    if not state_key or not args:
+        return span_name
+    state = args[0]
+    if isinstance(state, dict):
+        obj = state
+        for part in state_key.split("."):
+            if isinstance(obj, dict):
+                obj = obj.get(part)
+            else:
+                obj = getattr(obj, part, None)
+            if obj is None:
+                break
+        if obj is not None:
+            return f"{span_name} [{obj}]"
+    return span_name
+
+
+def _client():
+    """Get the Langfuse client from module namespace (respects test patches)."""
+    return _sys.modules[__name__].get_client()
+
+
+# ---------------------------------------------------------------------------
+# Public: langfuse_node — wrap LangGraph node functions
+# ---------------------------------------------------------------------------
+def langfuse_node(fn, name: str | None = None, state_key: str | None = None):
     """Wrap a LangGraph node function with a Langfuse span.
 
-    Args:
-        fn: Node function (sync or async). May take (state,) or (state, config, ...).
-            Also works with callable instances (e.g. ToolNode).
-        name: Span name override. Defaults to fn.__name__.
+    Works for sync and async nodes. Uses start_as_current_span so child calls
+    (LLM, sub-agents) automatically nest under this span.
 
-    Returns:
-        Wrapped function with identical call signature.
+    Args:
+        fn: Node function (sync or async).
+        name: Span name override. Defaults to fn.__name__.
+        state_key: Dot-delimited key into state dict to append to span name
+                   (e.g. "section.name" → "orchestration [半導體分析]").
     """
     span_name = name if name is not None else fn.__name__
-    # Read 'observe' from the current module namespace at call time so that test patches
-    # applied to Utils.langfuse_tracing.observe are respected.
-    _observe = _sys.modules[__name__].observe
 
     if inspect.iscoroutinefunction(fn):
-        # Decorator order: @_observe(name=span_name) is the outermost decorator,
-        # @functools.wraps(fn) is inner. Convention is wraps as innermost, which is
-        # what we do here. The span name comes from the explicit `name` parameter, not
-        # from fn.__name__, so the order has no effect on span naming.
-        @_observe(name=span_name)
         @functools.wraps(fn)
         async def async_wrapper(*args, **kwargs):
-            return await fn(*args, **kwargs)
+            dynamic_name = _get_dynamic_span_name(span_name, state_key, args)
+            with _client().start_as_current_span(name=dynamic_name):
+                return await fn(*args, **kwargs)
         return async_wrapper
     else:
-        @_observe(name=span_name)
         @functools.wraps(fn)
         def sync_wrapper(*args, **kwargs):
-            return fn(*args, **kwargs)
+            dynamic_name = _get_dynamic_span_name(span_name, state_key, args)
+            with _client().start_as_current_span(name=dynamic_name):
+                return fn(*args, **kwargs)
         return sync_wrapper
 
 
+# ---------------------------------------------------------------------------
+# Public: traced — context manager for manual spans
+# ---------------------------------------------------------------------------
+def traced(name: str):
+    """Create a Langfuse span as a context manager (sync `with` only).
+
+    Use this for wrapping arbitrary code blocks, e.g. inside asyncio.gather closures:
+
+        async def _do_web():
+            with traced("agentic_web_search"):
+                return await agentic_search_graph.ainvoke(...)
+
+    The returned context manager only supports `with`, not `async with`.
+    For async nodes, use langfuse_node() instead.
+    """
+    return _client().start_as_current_span(name=name)
+
+
+# ---------------------------------------------------------------------------
+# Public: traced_thread — run sync fn in thread with span propagation
+# ---------------------------------------------------------------------------
+async def traced_thread(fn, *args, **kwargs):
+    """Run a sync function in asyncio.to_thread with OTel context propagated.
+
+    Solves the problem where asyncio.to_thread breaks Langfuse span nesting
+    because the worker thread gets an empty OTel context.
+
+    Usage:
+        result = await traced_thread(graph.invoke, initial_state, config)
+
+    Instead of:
+        # BAD: spans inside graph.invoke become orphans
+        result = await asyncio.to_thread(graph.invoke, initial_state, config)
+    """
+    from opentelemetry import context as otel_context
+
+    parent_ctx = otel_context.get_current()
+
+    def _run():
+        token = otel_context.attach(parent_ctx)
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            otel_context.detach(token)
+
+    return await asyncio.to_thread(_run)
+
+
+# ---------------------------------------------------------------------------
+# Public: get_langfuse_callback — LangChain integration
+# ---------------------------------------------------------------------------
 def get_langfuse_callback():
     """Return a LangChain CallbackHandler linked to the current Langfuse trace.
 
     Returns None when called outside a @observe context to avoid creating
     spurious root traces for standalone LLM calls.
-
-    Usage in call_llm / call_llm_async:
-        handler = get_langfuse_callback()
-        callbacks = [handler] if handler else []
-        model.invoke(prompt, config={"callbacks": callbacks})
     """
-    _mod = _sys.modules[__name__]
-    client = _mod.get_client()
+    client = _client()
     if not client.get_current_trace_id():
         return None
-    return _mod.CallbackHandler()
+    return _sys.modules[__name__].CallbackHandler()

--- a/report_writer.py
+++ b/report_writer.py
@@ -69,6 +69,7 @@ from Tools.tools import (
     refine_section_formatter,
     section_formatter,
 )
+from Utils.langfuse_tracing import langfuse_node, traced
 from Utils.utils import (
     call_llm,
     call_llm_async,
@@ -404,13 +405,14 @@ async def orchestration(state: SectionState, config: RunnableConfig):
     if use_web:
         agentic_search_iterations = configurable.get("agentic_search_iterations", 1)
         agentic_search_queries = configurable.get("agentic_search_queries", 3)
-        search_results = await agentic_search_graph.ainvoke({
-            "question": current_question.question,
-            "max_num_iterations": agentic_search_iterations,
-            "num_queries": agentic_search_queries,
-            "url_memo": [],
-            "source_registry": [],
-        })
+        with traced("agentic_web_search"):
+            search_results = await agentic_search_graph.ainvoke({
+                "question": current_question.question,
+                "max_num_iterations": agentic_search_iterations,
+                "num_queries": agentic_search_queries,
+                "url_memo": [],
+                "source_registry": [],
+            })
         answer = search_results.get("answer", "")
         web_block = (
             f"## Research Iteration {iteration_num}\n"
@@ -772,9 +774,10 @@ class ReportGraphBuilder:
     def _build_section_graph(self) -> StateGraph:
         """Build the section subgraph (shared by sync/async)."""
         section_builder = StateGraph(SectionState, output_schema=SectionOutputState)
-        section_builder.add_node("generate_question", langfuse_node(generate_question))
-        section_builder.add_node("orchestration",     langfuse_node(orchestration))
-        section_builder.add_node("write_section",     langfuse_node(write_section))
+        _sk = "section.name"  # state_key: disambiguate parallel section spans
+        section_builder.add_node("generate_question", langfuse_node(generate_question, state_key=_sk))
+        section_builder.add_node("orchestration", langfuse_node(orchestration, state_key=_sk))
+        section_builder.add_node("write_section", langfuse_node(write_section, state_key=_sk))
 
         section_builder.add_edge(START, "generate_question")
         section_builder.add_edge("generate_question", "orchestration")
@@ -782,17 +785,43 @@ class ReportGraphBuilder:
 
         return section_builder
 
+    @staticmethod
+    def _make_section_wrapper(compiled_section_graph):
+        """Create a traced wrapper around the compiled section subgraph.
+
+        Wraps the subgraph invocation in a ``section_writer [name]`` Langfuse
+        span so that internal nodes (generate_question, orchestration,
+        write_section) nest under it instead of appearing flat at root level.
+        """
+
+        async def _section_writer(state: SectionState, config: RunnableConfig) -> dict:
+            section_name = state.get("section", {})
+            if hasattr(section_name, "name"):
+                section_name = section_name.name
+            elif isinstance(section_name, dict):
+                section_name = section_name.get("name", "")
+            span_name = f"section_writer [{section_name}]" if section_name else "section_writer"
+
+            with traced(span_name):
+                result = await compiled_section_graph.ainvoke(state, config)
+            return result
+
+        return _section_writer
+
     def _build_main_graph(self, section_graph: StateGraph) -> StateGraph:
         """Build the main report graph (shared by sync/async)."""
         builder = StateGraph(ReportState, input_schema=ReportStateInput, output_schema=ReportStateOutput)
-        builder.add_node("generate_report_plan",           langfuse_node(generate_report_plan))
-        builder.add_node("human_feedback",                  langfuse_node(human_feedback))
-        builder.add_node("build_section_with_web_research", section_graph.compile())
-        builder.add_node("route",                           langfuse_node(route_node))
-        builder.add_node("refine_sections",                 langfuse_node(refine_sections))
-        builder.add_node("gather_complete_section",         langfuse_node(gather_complete_section))
-        builder.add_node("write_final_sections",            langfuse_node(write_final_sections))
-        builder.add_node("compile_final_report",            langfuse_node(compile_final_report))
+        builder.add_node("generate_report_plan", langfuse_node(generate_report_plan))
+        builder.add_node("human_feedback", langfuse_node(human_feedback))
+        builder.add_node(
+            "build_section_with_web_research",
+            self._make_section_wrapper(section_graph.compile()),
+        )
+        builder.add_node("route", langfuse_node(route_node))
+        builder.add_node("refine_sections", langfuse_node(refine_sections))
+        builder.add_node("gather_complete_section", langfuse_node(gather_complete_section))
+        builder.add_node("write_final_sections", langfuse_node(write_final_sections))
+        builder.add_node("compile_final_report", langfuse_node(compile_final_report))
 
         builder.add_edge(START, "generate_report_plan")
         builder.add_edge("generate_report_plan", "human_feedback")

--- a/subagent/agentic_search.py
+++ b/subagent/agentic_search.py
@@ -23,6 +23,7 @@ BACKUP_MODEL_NAME = config["BACKUP_MODEL_NAME"]
 VERIFY_MODEL_NAME = config["VERIFY_MODEL_NAME"]
 BACKUP_VERIFY_MODEL_NAME = config["BACKUP_VERIFY_MODEL_NAME"]
 
+import chromadb
 from langchain_community.callbacks.infino_callback import get_num_tokens
 from langchain_community.vectorstores import Chroma
 from langchain_core.documents import Document
@@ -49,8 +50,7 @@ from Utils.utils import (
     call_search_api,
     web_search_deduplicate_and_format_sources,
 )
-from langfuse import observe
-from Utils.langfuse_tracing import langfuse_node
+from Utils.langfuse_tracing import langfuse_node, observe
 
 # Setup logger
 logger = logging.getLogger("AgenticSearch")
@@ -244,7 +244,6 @@ def perform_web_search(state: AgenticSearchState):
     }
 
 
-@observe(name="filter_and_format_results")
 async def filter_and_format_results(state: AgenticSearchState):
     followed_up_queries = state.get("followed_up_queries", [])
     queries = followed_up_queries if followed_up_queries else state["queries"]
@@ -307,7 +306,6 @@ async def filter_and_format_results(state: AgenticSearchState):
     return {"filtered_web_results": filtered_web_results}
 
 
-@observe(name="compress_raw_content")
 async def compress_raw_content(state: AgenticSearchState):
     followed_up_queries = state.get("followed_up_queries", [])
     queries = followed_up_queries if followed_up_queries else state["queries"]
@@ -563,7 +561,12 @@ def chunk_large_articles(state: AgenticSearchState) -> dict:
             try:
                 docs = [Document(chunk) for chunk in splitter.split_text(raw)]
                 collection_name = f"chunk_{uuid.uuid4().hex}"  # unique name avoids cross-article conflicts
-                vs = Chroma.from_documents(docs, embeddings, collection_name=collection_name)
+                ephemeral_client = chromadb.EphemeralClient()
+                vs = Chroma.from_documents(
+                    docs, embeddings,
+                    collection_name=collection_name,
+                    client=ephemeral_client,
+                )
                 try:
                     hits = vs.similarity_search(query, k=5)
                 finally:
@@ -596,14 +599,10 @@ class AgenticSearchGraphBuilder:
             builder.add_node("get_searching_budget",           langfuse_node(get_searching_budget))
             builder.add_node("generate_queries_from_question", langfuse_node(generate_queries_from_question))
             builder.add_node("perform_web_search",             langfuse_node(perform_web_search))
-            # Registered without langfuse_node: these are async functions and langfuse_node
-            # wrapping async nodes silently drops spans in Langfuse 3.x OTLP mode.
-            # @observe is applied directly on the function definitions above instead.
-            # Sync nodes (all others in this graph) use langfuse_node safely.
-            builder.add_node("filter_and_format_results",      filter_and_format_results)
+            builder.add_node("filter_and_format_results",      langfuse_node(filter_and_format_results))
             builder.add_node("crawl_filtered_results",         langfuse_node(crawl_filtered_results))
             builder.add_node("chunk_large_articles",           langfuse_node(chunk_large_articles))
-            builder.add_node("compress_raw_content",           compress_raw_content)
+            builder.add_node("compress_raw_content",           langfuse_node(compress_raw_content))
             builder.add_node("aggregate_final_results",        langfuse_node(aggregate_final_results))
             builder.add_node("synthesize_answer",              langfuse_node(synthesize_answer))
             builder.add_node("check_searching_results",        langfuse_node(check_searching_results))

--- a/subagent/document_qa.py
+++ b/subagent/document_qa.py
@@ -27,8 +27,7 @@ from State.document_qa_state import DocumentQAState
 from Tools.reader_models import FileReference
 from Tools.text_navigator import AgentDocumentReader
 from Utils.utils import call_llm
-from langfuse import observe
-from Utils.langfuse_tracing import langfuse_node
+from Utils.langfuse_tracing import langfuse_node, observe, traced_thread
 
 # Load configurations
 _HERE = pathlib.Path(__file__).parent.parent
@@ -402,7 +401,7 @@ async def run_document_qa_async(
     navigator, graph, initial_state, invoke_config = _prepare_qa_session(file_paths, question, budget)
 
     try:
-        result = await asyncio.to_thread(graph.invoke, initial_state, invoke_config)
+        result = await traced_thread(graph.invoke, initial_state, invoke_config)
     finally:
         navigator.close_document()
 

--- a/tests/test_langfuse_tracing.py
+++ b/tests/test_langfuse_tracing.py
@@ -5,9 +5,20 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+def _make_mock_client():
+    """Create a mock Langfuse client with start_as_current_span returning a context manager."""
+    mock_client = MagicMock()
+    mock_span_ctx = MagicMock()
+    mock_span_ctx.__enter__ = MagicMock(return_value=mock_span_ctx)
+    mock_span_ctx.__exit__ = MagicMock(return_value=False)
+    mock_client.start_as_current_span.return_value = mock_span_ctx
+    return mock_client
+
+
 def test_langfuse_node_wraps_sync_function():
     """langfuse_node wraps a sync function, preserving __name__ and behavior."""
-    with patch("Utils.langfuse_tracing.observe", lambda **kw: (lambda fn: fn)):
+    mock_client = _make_mock_client()
+    with patch("Utils.langfuse_tracing.get_client", return_value=mock_client):
         from importlib import reload
         import Utils.langfuse_tracing
         reload(Utils.langfuse_tracing)
@@ -23,7 +34,8 @@ def test_langfuse_node_wraps_sync_function():
 
 def test_langfuse_node_wraps_async_function():
     """langfuse_node wraps an async function, preserving __name__ and behavior."""
-    with patch("Utils.langfuse_tracing.observe", lambda **kw: (lambda fn: fn)):
+    mock_client = _make_mock_client()
+    with patch("Utils.langfuse_tracing.get_client", return_value=mock_client):
         from importlib import reload
         import Utils.langfuse_tracing
         reload(Utils.langfuse_tracing)
@@ -40,7 +52,8 @@ def test_langfuse_node_wraps_async_function():
 
 def test_langfuse_node_passes_extra_args():
     """langfuse_node passes extra args (e.g. config: RunnableConfig) through unchanged."""
-    with patch("Utils.langfuse_tracing.observe", lambda **kw: (lambda fn: fn)):
+    mock_client = _make_mock_client()
+    with patch("Utils.langfuse_tracing.get_client", return_value=mock_client):
         from importlib import reload
         import Utils.langfuse_tracing
         reload(Utils.langfuse_tracing)
@@ -54,14 +67,9 @@ def test_langfuse_node_passes_extra_args():
 
 
 def test_langfuse_node_uses_function_name_as_span_name():
-    """langfuse_node calls observe(name=fn.__name__)."""
-    observed_kwargs = []
-
-    def fake_observe(**kwargs):
-        observed_kwargs.append(kwargs)
-        return lambda fn: fn
-
-    with patch("Utils.langfuse_tracing.observe", fake_observe):
+    """langfuse_node passes fn.__name__ to start_as_current_span."""
+    mock_client = _make_mock_client()
+    with patch("Utils.langfuse_tracing.get_client", return_value=mock_client):
         from importlib import reload
         import Utils.langfuse_tracing
         reload(Utils.langfuse_tracing)
@@ -70,19 +78,15 @@ def test_langfuse_node_uses_function_name_as_span_name():
         def perform_web_search(state):
             return {}
 
-        langfuse_node(perform_web_search)
-        assert any(kw.get("name") == "perform_web_search" for kw in observed_kwargs)
+        wrapped = langfuse_node(perform_web_search)
+        wrapped({})
+        mock_client.start_as_current_span.assert_called_once_with(name="perform_web_search")
 
 
 def test_langfuse_node_accepts_name_override():
     """langfuse_node uses explicit name= override when provided."""
-    observed_kwargs = []
-
-    def fake_observe(**kwargs):
-        observed_kwargs.append(kwargs)
-        return lambda fn: fn
-
-    with patch("Utils.langfuse_tracing.observe", fake_observe):
+    mock_client = _make_mock_client()
+    with patch("Utils.langfuse_tracing.get_client", return_value=mock_client):
         from importlib import reload
         import Utils.langfuse_tracing
         reload(Utils.langfuse_tracing)
@@ -91,8 +95,46 @@ def test_langfuse_node_accepts_name_override():
         def tool_node_fn(state):
             return {}
 
-        langfuse_node(tool_node_fn, name="tools")
-        assert any(kw.get("name") == "tools" for kw in observed_kwargs)
+        wrapped = langfuse_node(tool_node_fn, name="tools")
+        wrapped({})
+        mock_client.start_as_current_span.assert_called_once_with(name="tools")
+
+
+def test_langfuse_node_state_key_appends_section_name():
+    """langfuse_node with state_key appends the value from state to span name."""
+    mock_client = _make_mock_client()
+    with patch("Utils.langfuse_tracing.get_client", return_value=mock_client):
+        from importlib import reload
+        import Utils.langfuse_tracing
+        reload(Utils.langfuse_tracing)
+        from Utils.langfuse_tracing import langfuse_node
+
+        section = MagicMock()
+        section.name = "半導體分析"
+
+        def my_node(state):
+            return {}
+
+        wrapped = langfuse_node(my_node, state_key="section.name")
+        wrapped({"section": section})
+        mock_client.start_as_current_span.assert_called_once_with(name="my_node [半導體分析]")
+
+
+def test_langfuse_node_state_key_missing_falls_back():
+    """langfuse_node with state_key falls back to base name when key not in state."""
+    mock_client = _make_mock_client()
+    with patch("Utils.langfuse_tracing.get_client", return_value=mock_client):
+        from importlib import reload
+        import Utils.langfuse_tracing
+        reload(Utils.langfuse_tracing)
+        from Utils.langfuse_tracing import langfuse_node
+
+        def my_node(state):
+            return {}
+
+        wrapped = langfuse_node(my_node, state_key="section.name")
+        wrapped({"other_key": "value"})
+        mock_client.start_as_current_span.assert_called_once_with(name="my_node")
 
 
 def test_get_langfuse_callback_returns_handler_inside_trace():


### PR DESCRIPTION
## Summary
- Rewrite `Utils/langfuse_tracing.py` into a unified tracing API with 4 public functions: `langfuse_node`, `traced`, `traced_thread`, `observe`
- All application code now imports exclusively from `Utils.langfuse_tracing` (never from `langfuse` directly), ensuring consistent context propagation and test patchability
- Add `section_writer` wrapper with `traced()` so subgraph nodes nest under a parent span instead of appearing flat at root level
- Add `state_key` disambiguation for parallel section spans (e.g. `orchestration [半導體分析]`)
- Fix `asyncio.to_thread` → `traced_thread` in `document_qa` to propagate OTel context to worker threads
- Wrap async nodes (`filter_and_format_results`, `compress_raw_content`) with `langfuse_node` in `agentic_search`
- Use `chromadb.EphemeralClient()` for `chunk_large_articles` to prevent `SharedSystemClient` singleton contamination

## Tracing API Reference

| Function | When to use |
|----------|-------------|
| `langfuse_node(fn, name=, state_key=)` | Wrap every LangGraph node in `add_node()` |
| `traced(name)` | Context-manager span for `asyncio.gather` closures or code blocks |
| `traced_thread(fn, *a, **kw)` | Run sync fn in `asyncio.to_thread` with OTel context propagated |
| `observe` | Decorate top-level entry points and standalone utility functions |

## Expected Nesting Structure

```
report_writer (@observe)
├── generate_report_plan
├── section_writer [Section A]          ← traced() wrapper
│   ├── generate_question [Section A]   ← state_key
│   ├── orchestration [Section A]
│   │   └── agentic_web_search (traced)
│   │       ├── get_searching_budget
│   │       ├── perform_web_search
│   │       └── ...
│   └── write_section [Section A]
├── section_writer [Section B]
│   └── ...
└── compile_final_report
```

## Test plan
- [x] All 316 tests pass, 2 skipped (unrelated Yuanta tests)
- [ ] Run a live report to verify nested span structure in Langfuse UI


🤖 Generated with [Claude Code](https://claude.com/claude-code)